### PR TITLE
Feat/5/create todo

### DIFF
--- a/pages/create.tsx
+++ b/pages/create.tsx
@@ -1,0 +1,5 @@
+import Layout from "src/layouts";
+
+export default function Create() {
+  return <Layout>Create To-Dos</Layout>;
+}

--- a/pages/create.tsx
+++ b/pages/create.tsx
@@ -1,5 +1,10 @@
 import Layout from "src/layouts";
+import CreateToDo from "src/components/create";
 
 export default function Create() {
-  return <Layout>Create To-Dos</Layout>;
+  return (
+    <Layout>
+      <CreateToDo />
+    </Layout>
+  );
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,10 @@
 import Layout from "src/layouts";
+import PlusButton from "src/components/home/plus-button";
 
 export default function Home() {
-  return <Layout>Hello, World!</Layout>;
+  return (
+    <Layout>
+      <PlusButton />
+    </Layout>
+  );
 }

--- a/src/assets/icons/chevron/down.tsx
+++ b/src/assets/icons/chevron/down.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+import { IconProps } from "../icons";
+
+export default function Icon({ style, fill }: IconProps) {
+  return (
+    <svg style={style} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+      <g transform="rotate(180 471.5 283)">
+        <path
+          d="M.225 7.149a.769.769 0 0 0 1.088 1.087l3.462-3.461a.769.769 0 0 0 0-1.088L1.313.226A.769.769 0 1 0 .225 1.313l2.918 2.918z"
+          fill={fill}
+          transform="rotate(-90 741.9 -185.369)"
+        />
+        <path d="M0 0h24v24H0z" fill="none" transform="translate(919 542)" />
+      </g>
+    </svg>
+  );
+}

--- a/src/assets/icons/chevron/left.tsx
+++ b/src/assets/icons/chevron/left.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+
+import { IconProps } from "../icons";
+
+export default function Icon({ style, fill }: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      style={style}
+      fill="none"
+      stroke={fill}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+      viewBox="0 0 24 24"
+    >
+      <path d="M15 18L9 12 15 6"></path>
+    </svg>
+  );
+}

--- a/src/assets/icons/chevron/up.tsx
+++ b/src/assets/icons/chevron/up.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+import { IconProps } from "../icons";
+
+export default function Icon({ style, fill }: IconProps) {
+  return (
+    <svg style={style} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+      <g transform="translate(-919 -542)">
+        <path
+          fill={fill}
+          d="M.225 7.149a.769.769 0 0 0 1.088 1.087l3.462-3.461a.769.769 0 0 0 0-1.088L1.313.226A.769.769 0 1 0 .225 1.313l2.918 2.918z"
+          transform="rotate(-90 741.9 -185.369)"
+        />
+        <path fill="none" d="M0 0h24v24H0z" transform="translate(919 542)" />
+      </g>
+    </svg>
+  );
+}

--- a/src/assets/icons/plus.tsx
+++ b/src/assets/icons/plus.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+import { IconProps } from "./icons";
+
+function PlusIcon({ style, fill }: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      style={style}
+      fill="none"
+      stroke={fill}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+      viewBox="0 0 24 24"
+    >
+      <path d="M12 5L12 19"></path>
+      <path d="M5 12L19 12"></path>
+    </svg>
+  );
+}
+
+export default PlusIcon;

--- a/src/components/create/color-select.tsx
+++ b/src/components/create/color-select.tsx
@@ -1,16 +1,21 @@
 import styled from "styled-components";
 
-export default function ColorSelect() {
+type ColorSelectProps = {
+  handleColorChange: (event: React.ChangeEvent<HTMLSelectElement>) => void;
+};
+
+export default function ColorSelect({ handleColorChange }: ColorSelectProps) {
+  const OPTIONS = ["red", "orange", "yellow", "green", "blue", "purple"];
+
   return (
     <InputGroup>
       <Label htmlFor="color">Color</Label>
-      <Select id="color">
-        <Option value="red">red</Option>
-        <Option value="orange">orange</Option>
-        <Option value="yellow">yellow</Option>
-        <Option value="green">green</Option>
-        <Option value="blue">blue</Option>
-        <Option value="grey">grey</Option>
+      <Select id="color" onChange={handleColorChange}>
+        {OPTIONS.map((value) => (
+          <Option key={value} value={value}>
+            {value}
+          </Option>
+        ))}
       </Select>
     </InputGroup>
   );

--- a/src/components/create/color-select.tsx
+++ b/src/components/create/color-select.tsx
@@ -1,0 +1,36 @@
+import styled from "styled-components";
+
+export default function ColorSelect() {
+  return (
+    <InputGroup>
+      <Label htmlFor="color">Color</Label>
+      <Select id="color">
+        <Option value="red">red</Option>
+        <Option value="orange">orange</Option>
+        <Option value="yellow">yellow</Option>
+        <Option value="green">green</Option>
+        <Option value="blue">blue</Option>
+        <Option value="grey">grey</Option>
+      </Select>
+    </InputGroup>
+  );
+}
+
+const InputGroup = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 2rem;
+`;
+
+const Label = styled.label`
+  font-size: 1.6rem;
+  font-weight: 500;
+`;
+
+const Select = styled.select`
+  font-size: 1.5rem;
+  width: 70%;
+`;
+
+const Option = styled.option``;

--- a/src/components/create/index.tsx
+++ b/src/components/create/index.tsx
@@ -1,3 +1,5 @@
+import { useState } from "react";
+import { useRouter } from "next/router";
 import styled from "styled-components";
 
 import { GREEN, WHITE } from "@colors";
@@ -6,20 +8,94 @@ import ColorSelect from "./color-select";
 import ShareCheckbox from "./share-checkbox";
 
 export default function CreateToDo() {
+  const [task, setTask] = useState<string>("");
+  const [deadline, setDeadline] = useState<string>("");
+  const [priority, setPriority] = useState<string>("1");
+  const [color, setColor] = useState<string>("red");
+  const [emailList, setEmailList] = useState<Set<string>>(new Set());
+  const [isDone, setIsDone] = useState<boolean>(false);
+
+  const router = useRouter();
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const data = {
+      task,
+      deadline,
+      priority,
+      color,
+      emailList: Array.from(emailList),
+      isDone,
+    };
+
+    const list = JSON.parse(localStorage.getItem("toDoList") || "[]");
+
+    if (router.query.id) {
+      const id = router.query.id.toString();
+      list[id] = data;
+      localStorage.setItem("toDoList", JSON.stringify(list));
+    } else {
+      localStorage.setItem("toDoList", JSON.stringify([...list, data]));
+    }
+    router.push("/");
+  };
+
+  const handleTaskChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setTask(event.target.value);
+  };
+
+  const handleDeadlineChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setDeadline(event.target.value);
+  };
+
+  const handlePriorityChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setPriority(event.currentTarget.value);
+  };
+
+  const handleColorChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    setColor(event.target.value);
+  };
+
+  const handleEmailListChange = (email: string, isChecked: boolean) => {
+    if (isChecked) {
+      emailList.add(email);
+      setEmailList(emailList);
+    } else if (!isChecked && emailList.has(email)) {
+      emailList.delete(email);
+      setEmailList(emailList);
+    }
+  };
+
   return (
     <Wrapper>
-      <StyledForm>
+      <StyledForm onSubmit={handleSubmit}>
         <InputGroup>
           <Label htmlFor="todo">To Do</Label>
-          <TaskInput type="text" id="todo" required />
+          <TaskInput
+            type="text"
+            id="todo"
+            value={task}
+            onChange={handleTaskChange}
+            required
+          />
         </InputGroup>
         <InputGroup>
           <Label htmlFor="deadline">Deadline</Label>
-          <DateInput type="date" id="deadline" required />
+          <DateInput
+            type="date"
+            id="deadline"
+            value={deadline}
+            onChange={handleDeadlineChange}
+            required
+          />
         </InputGroup>
-        <PriorityRadiogroup />
-        <ColorSelect />
-        <ShareCheckbox />
+        <PriorityRadiogroup
+          checkedValue={priority}
+          handlePriorityChange={handlePriorityChange}
+        />
+        <ColorSelect handleColorChange={handleColorChange} />
+        <ShareCheckbox handleEmailListChange={handleEmailListChange} />
         <SaveButton type="submit">Save</SaveButton>
       </StyledForm>
     </Wrapper>

--- a/src/components/create/index.tsx
+++ b/src/components/create/index.tsx
@@ -1,0 +1,72 @@
+import styled from "styled-components";
+
+import { GREEN, WHITE } from "@colors";
+import PriorityRadiogroup from "./priority-radiogroup";
+import ColorSelect from "./color-select";
+import ShareCheckbox from "./share-checkbox";
+
+export default function CreateToDo() {
+  return (
+    <Wrapper>
+      <StyledForm>
+        <InputGroup>
+          <Label htmlFor="todo">To Do</Label>
+          <TaskInput type="text" id="todo" required />
+        </InputGroup>
+        <InputGroup>
+          <Label htmlFor="deadline">Deadline</Label>
+          <DateInput type="date" id="deadline" required />
+        </InputGroup>
+        <PriorityRadiogroup />
+        <ColorSelect />
+        <ShareCheckbox />
+        <SaveButton type="submit">Save</SaveButton>
+      </StyledForm>
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.div`
+  padding: 2rem;
+`;
+
+const StyledForm = styled.form`
+  display: flex;
+  flex-direction: column;
+`;
+
+const InputGroup = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 2rem;
+`;
+
+const Label = styled.label`
+  font-size: 1.6rem;
+  font-weight: 500;
+`;
+
+const TaskInput = styled.input`
+  font-size: 1.5rem;
+  width: 70%;
+`;
+
+const DateInput = styled.input`
+  font-size: 1.5rem;
+  width: 70%;
+`;
+
+const SaveButton = styled.button`
+  width: 12rem;
+  height: 4rem;
+  border-radius: 1rem;
+  background-color: ${GREEN};
+  color: ${WHITE};
+  font-size: 1.6rem;
+  font-weight: 500;
+  position: absolute;
+  left: calc(50% - 6rem);
+  bottom: 3rem;
+  border: none;
+`;

--- a/src/components/create/priority-radiogroup.tsx
+++ b/src/components/create/priority-radiogroup.tsx
@@ -5,7 +5,12 @@ export default function PriorityRadiogroup() {
 
   const RadioItem = (value) => (
     <RadioWrapper key={value}>
-      <RadioInput type="radio" value={value} id={value} />
+      <RadioInput
+        type="radio"
+        value={value}
+        id={value}
+        defaultChecked={value === "1"}
+      />
       <RadioLabel htmlFor={value}>{value}</RadioLabel>
     </RadioWrapper>
   );

--- a/src/components/create/priority-radiogroup.tsx
+++ b/src/components/create/priority-radiogroup.tsx
@@ -1,0 +1,51 @@
+import styled from "styled-components";
+
+export default function PriorityRadiogroup() {
+  const OPTIONS = ["1", "2", "3", "4", "5"];
+
+  const RadioItem = (value) => (
+    <RadioWrapper key={value}>
+      <RadioInput type="radio" value={value} id={value} />
+      <RadioLabel htmlFor={value}>{value}</RadioLabel>
+    </RadioWrapper>
+  );
+
+  return (
+    <InputGroup>
+      <Label htmlFor="priority">Priority</Label>
+      <RadioGroupWrapper>
+        {OPTIONS.map((value) => RadioItem(value))}
+      </RadioGroupWrapper>
+    </InputGroup>
+  );
+}
+
+const InputGroup = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 2rem;
+`;
+
+const Label = styled.label`
+  font-size: 1.6rem;
+  font-weight: 500;
+`;
+
+const RadioGroupWrapper = styled.div`
+  width: 70%;
+  display: flex;
+  justify-content: space-between;
+`;
+
+const RadioWrapper = styled.div`
+  display: flex;
+  align-items: baseline;
+`;
+
+const RadioInput = styled.input``;
+
+const RadioLabel = styled.label`
+  font-size: 1.5rem;
+  margin-left: 0.4rem;
+`;

--- a/src/components/create/priority-radiogroup.tsx
+++ b/src/components/create/priority-radiogroup.tsx
@@ -1,26 +1,33 @@
 import styled from "styled-components";
 
-export default function PriorityRadiogroup() {
+type PriorityRadiogroupProps = {
+  checkedValue: string;
+  handlePriorityChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+};
+
+export default function PriorityRadiogroup({
+  checkedValue,
+  handlePriorityChange,
+}: PriorityRadiogroupProps) {
   const OPTIONS = ["1", "2", "3", "4", "5"];
 
-  const RadioItem = (value) => (
+  const renderRadioItems = OPTIONS.map((value) => (
     <RadioWrapper key={value}>
       <RadioInput
         type="radio"
         value={value}
         id={value}
-        defaultChecked={value === "1"}
+        checked={value === checkedValue}
+        onChange={handlePriorityChange}
       />
       <RadioLabel htmlFor={value}>{value}</RadioLabel>
     </RadioWrapper>
-  );
+  ));
 
   return (
     <InputGroup>
       <Label htmlFor="priority">Priority</Label>
-      <RadioGroupWrapper>
-        {OPTIONS.map((value) => RadioItem(value))}
-      </RadioGroupWrapper>
+      <RadioGroupWrapper>{renderRadioItems}</RadioGroupWrapper>
     </InputGroup>
   );
 }

--- a/src/components/create/share-checkbox/email-checkboxes.tsx
+++ b/src/components/create/share-checkbox/email-checkboxes.tsx
@@ -1,6 +1,13 @@
+import { WHITE } from "@colors";
 import styled from "styled-components";
 
-export default function EmailCheckboxes() {
+import Email from "./email";
+
+export default function EmailCheckboxes({
+  handleEmailListChange,
+}: {
+  handleEmailListChange: (email: string, isChecked: boolean) => void;
+}) {
   const EMAILS = [
     "example1@example.com",
     "example2@example.com",
@@ -11,10 +18,11 @@ export default function EmailCheckboxes() {
   return (
     <ContentWrapper>
       {EMAILS.map((value) => (
-        <CheckboxWrapper key={value}>
-          <Checkbox type="checkbox" id={value} value={value} />
-          <Label htmlFor={value}>{value}</Label>
-        </CheckboxWrapper>
+        <Email
+          key={value}
+          value={value}
+          handleEmailListChange={handleEmailListChange}
+        />
       ))}
     </ContentWrapper>
   );
@@ -22,25 +30,10 @@ export default function EmailCheckboxes() {
 
 const ContentWrapper = styled.div`
   width: 100%;
-  max-height: 20em;
-  overflow-x: scroll;
+  max-height: 20rem;
+  overflow-y: scroll;
   display: flex;
   flex-direction: column;
   padding: 5rem 1.6rem 0.4rem 1.6rem;
-`;
-
-const CheckboxWrapper = styled.div`
-  display: flex;
-  align-items: center;
-  margin-bottom: 1rem;
-`;
-
-const Label = styled.label`
-  font-size: 1.2rem;
-`;
-
-const Checkbox = styled.input`
-  width: 1.2rem;
-  height: 1.2rem;
-  margin-right: 0.8rem;
+  background-color: ${WHITE};
 `;

--- a/src/components/create/share-checkbox/email-checkboxes.tsx
+++ b/src/components/create/share-checkbox/email-checkboxes.tsx
@@ -1,0 +1,44 @@
+import styled from "styled-components";
+
+export default function EmailCheckboxes() {
+  const EMAILS = [
+    "example1@example.com",
+    "example2@example.com",
+    "example3@example.com",
+    "example4@example.com",
+  ];
+
+  return (
+    <ContentWrapper>
+      {EMAILS.map((value) => (
+        <CheckboxWrapper key={value}>
+          <Checkbox type="checkbox" id={value} value={value} />
+          <Label htmlFor={value}>{value}</Label>
+        </CheckboxWrapper>
+      ))}
+    </ContentWrapper>
+  );
+}
+
+const ContentWrapper = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  padding: 5rem 1.6rem 0.4rem 1.6rem;
+`;
+
+const CheckboxWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  margin-bottom: 1rem;
+`;
+
+const Label = styled.label`
+  font-size: 1.2rem;
+`;
+
+const Checkbox = styled.input`
+  width: 1.2rem;
+  height: 1.2rem;
+  margin-right: 0.8rem;
+`;

--- a/src/components/create/share-checkbox/email-checkboxes.tsx
+++ b/src/components/create/share-checkbox/email-checkboxes.tsx
@@ -22,6 +22,8 @@ export default function EmailCheckboxes() {
 
 const ContentWrapper = styled.div`
   width: 100%;
+  max-height: 20em;
+  overflow-x: scroll;
   display: flex;
   flex-direction: column;
   padding: 5rem 1.6rem 0.4rem 1.6rem;

--- a/src/components/create/share-checkbox/email.tsx
+++ b/src/components/create/share-checkbox/email.tsx
@@ -1,0 +1,45 @@
+import { useState } from "react";
+import styled from "styled-components";
+
+type EmailProps = {
+  value: string;
+  handleEmailListChange: (email: string, isChecked: boolean) => void;
+};
+
+export default function Email({ value, handleEmailListChange }: EmailProps) {
+  const [isChecked, setIsChecked] = useState<boolean>(false);
+
+  const handleChecked = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setIsChecked(!isChecked);
+    handleEmailListChange(event.target.value, event.target.checked);
+  };
+
+  return (
+    <CheckboxWrapper key={value}>
+      <Checkbox
+        type="checkbox"
+        id={value}
+        value={value}
+        checked={isChecked}
+        onChange={handleChecked}
+      />
+      <Label htmlFor={value}>{value}</Label>
+    </CheckboxWrapper>
+  );
+}
+
+const CheckboxWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  margin-bottom: 1rem;
+`;
+
+const Label = styled.label`
+  font-size: 1.2rem;
+`;
+
+const Checkbox = styled.input`
+  width: 1.2rem;
+  height: 1.2rem;
+  margin-right: 0.8rem;
+`;

--- a/src/components/create/share-checkbox/header.tsx
+++ b/src/components/create/share-checkbox/header.tsx
@@ -1,0 +1,55 @@
+import styled, { css } from "styled-components";
+
+import Up from "src/assets/icons/chevron/up";
+import Down from "src/assets/icons/chevron/down";
+import { GREEN, WHITE } from "@colors";
+
+type HeaderProps = {
+  title: string;
+  isOpened: boolean;
+  toggleOpened: () => void;
+};
+
+export default function Header({ title, isOpened, toggleOpened }: HeaderProps) {
+  return (
+    <StyledHeader isOpened={isOpened}>
+      {isOpened ? (
+        <ChevronButton onClick={toggleOpened}>
+          <Up style={{ width: "3.6rem", height: "3.6rem" }} fill={WHITE} />
+        </ChevronButton>
+      ) : (
+        <ChevronButton onClick={toggleOpened}>
+          <Down style={{ width: "3.6rem", height: "3.6rem" }} fill={WHITE} />
+        </ChevronButton>
+      )}
+      <StyledH1>{title}</StyledH1>
+    </StyledHeader>
+  );
+}
+
+const StyledHeader = styled.header`
+  width: 100%;
+  height: 4rem;
+  background-color: ${GREEN};
+  border: 0.2rem solid ${GREEN};
+  box-shadow: rgba(0, 0, 0, 0.16) 0px 1px 6px 0px;
+  position: absolute;
+  top: 0;
+  display: flex;
+  align-items: center;
+  ${(props: { isOpened: boolean }) => css`
+    border-bottom-right-radius: ${props.isOpened ? 0 : "1rem"};
+    border-bottom-left-radius: ${props.isOpened ? 0 : "1rem"};
+  `}
+`;
+
+const ChevronButton = styled.button`
+  background-color: transparent;
+  border: none;
+`;
+
+const StyledH1 = styled.h1`
+  font-size: 1.4rem;
+  font-weight: bold;
+  color: ${WHITE};
+`;

--- a/src/components/create/share-checkbox/index.tsx
+++ b/src/components/create/share-checkbox/index.tsx
@@ -5,7 +5,11 @@ import { GREEN } from "@colors";
 import Header from "./header";
 import EmailCheckboxes from "./email-checkboxes";
 
-export default function ShareCheckbox() {
+export default function ShareCheckbox({
+  handleEmailListChange,
+}: {
+  handleEmailListChange: (email: string, isChecked: boolean) => void;
+}) {
   const [isOpened, setIsOpened] = useState<boolean>(true);
 
   const toggleOpened = () => {
@@ -19,7 +23,9 @@ export default function ShareCheckbox() {
         isOpened={isOpened}
         toggleOpened={toggleOpened}
       />
-      {isOpened && <EmailCheckboxes />}
+      {isOpened && (
+        <EmailCheckboxes handleEmailListChange={handleEmailListChange} />
+      )}
     </Wrapper>
   );
 }

--- a/src/components/create/share-checkbox/index.tsx
+++ b/src/components/create/share-checkbox/index.tsx
@@ -1,0 +1,34 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+
+import { GREEN } from "@colors";
+import Header from "./header";
+import EmailCheckboxes from "./email-checkboxes";
+
+export default function ShareCheckbox() {
+  const [isOpened, setIsOpened] = useState<boolean>(true);
+
+  const toggleOpened = () => {
+    setIsOpened(!isOpened);
+  };
+
+  return (
+    <Wrapper>
+      <Header
+        title="Share With Others"
+        isOpened={isOpened}
+        toggleOpened={toggleOpened}
+      />
+      {isOpened && <EmailCheckboxes />}
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.article`
+  width: 100%;
+  min-height: 4rem;
+  border-radius: 1rem;
+  border: 0.2rem solid ${GREEN};
+  position: relative;
+  overflow: hidden;
+`;

--- a/src/components/home/plus-button.tsx
+++ b/src/components/home/plus-button.tsx
@@ -1,0 +1,34 @@
+import Link from "next/link";
+import styled from "styled-components";
+
+import PlusIcon from "src/assets/icons/plus";
+import { GREEN, WHITE } from "@colors";
+
+export default function PlusButton() {
+  return (
+    <Link href="/create" passHref>
+      <A>
+        <CircleButton>
+          <PlusIcon style={{ width: "2rem", height: "2rem" }} fill={WHITE} />
+        </CircleButton>
+      </A>
+    </Link>
+  );
+}
+
+const A = styled.a``;
+
+const CircleButton = styled.button`
+  width: 3rem;
+  height: 3rem;
+  border-radius: 1.5rem;
+  background-color: ${GREEN};
+  position: absolute;
+  bottom: 2rem;
+  right: 2rem;
+  border: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: rgba(0, 0, 0, 0.16) 0px 2px 8px 0px;
+`;

--- a/src/layouts/header.tsx
+++ b/src/layouts/header.tsx
@@ -1,19 +1,36 @@
 import Link from "next/link";
+import { useRouter } from "next/router";
 import styled from "styled-components";
 
 import { WHITE, GREEN } from "src/constants/colors";
 import MenuIcon from "src/assets/icons/menu";
+import GoBackIcon from "src/assets/icons/chevron/left";
 
 export type GlobalHeaderProps = {
   toggleSidebar: () => void;
 };
 
 export default function GlobalHeader({ toggleSidebar }: GlobalHeaderProps) {
+  const router = useRouter();
+  const { pathname } = router;
+
+  const GoBackButton = (
+    <Button onClick={router.back}>
+      <GoBackIcon fill={WHITE} style={{ width: "2rem", height: "2rem" }} />
+    </Button>
+  );
+
+  const MenuButton = (
+    <Button onClick={toggleSidebar}>
+      <MenuIcon fill={WHITE} style={{ width: "2rem", height: "2rem" }} />
+    </Button>
+  );
+
+  const isCreateTodo = pathname === "/create";
+
   return (
     <Wrapper>
-      <Button onClick={toggleSidebar}>
-        <MenuIcon fill={WHITE} style={{ width: "2rem", height: "2rem" }} />
-      </Button>
+      {isCreateTodo ? GoBackButton : MenuButton}
       <Link href="/" passHref>
         <A>
           <Title>Log - Oh</Title>


### PR DESCRIPTION
## PR Description
투두 입력 화면으로 넘어가는 버튼을 홈 화면에 추가했습니다.
투두를 작성하는 폼을 만들었습니다.
저장 버튼을 눌렀을 때 로컬 스토리지에 저장하고 다시 홈 화면으로 리다이렉트되게 구현했습니다.
작성 화면에 들어갔을 때 헤더 왼쪽 버튼을 뒤로가기 버튼으로 변경했습니다.

## Related Issues

resolve #5 


## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.
- [x] Did you assigned `Assignee`?
- [x] Is there no `Blocking PR`? (If any, link to #n below.)
- [ x Are component's all props working properly?
- [x] Did you run `yarn tsc`?
